### PR TITLE
Apply sharp filters before upsizing

### DIFF
--- a/src/resize.rs
+++ b/src/resize.rs
@@ -62,15 +62,35 @@ pub fn magic_resize(
 
     let size = (image.width(), image.height());
 
-    let out = Kernel2D::new::<MagicKernel>(size, new_size).apply(image);
-    if version == Version::MagicKernel {
-        return out;
+    if new_size.0 >= size.0 {
+        match version {
+            Version::MagicKernel => {
+                Kernel2D::new::<MagicKernel>(size, new_size).apply(image)
+            }
+            Version::MagicKernelSharp2013 => {
+                let img = Kernel2D::new::<Sharp2013>(size, size).apply(image);
+                Kernel2D::new::<MagicKernel>(size, new_size).apply(&img)
+            }
+            Version::MagicKernelSharp2021 => {
+                let img = Kernel2D::new::<Sharp2013>(size, size).apply(image);
+                let img = Kernel2D::new::<Sharp2021>(size, size).apply(&img);
+                Kernel2D::new::<MagicKernel>(size, new_size).apply(&img)
+            }
+        }
+    } else {
+        match version {
+            Version::MagicKernel => {
+                Kernel2D::new::<MagicKernel>(size, new_size).apply(image)
+            }
+            Version::MagicKernelSharp2013 => {
+                let img = Kernel2D::new::<MagicKernel>(size, new_size).apply(image);
+                Kernel2D::new::<Sharp2013>(new_size, new_size).apply(&img)
+            }
+            Version::MagicKernelSharp2021 => {
+                let img = Kernel2D::new::<MagicKernel>(size, new_size).apply(image);
+                let img = Kernel2D::new::<Sharp2013>(new_size, new_size).apply(&img);
+                Kernel2D::new::<Sharp2021>(new_size, new_size).apply(&img)
+            }
+        }
     }
-    let out = Kernel2D::new::<Sharp2013>(new_size, new_size).apply(&out);
-    if version == Version::MagicKernelSharp2013 {
-        return out;
-    }
-
-    // Sharp 2021 version
-    Kernel2D::new::<Sharp2021>(new_size, new_size).apply(&out)
 }


### PR DESCRIPTION
Comparing results of this library with the ANSI C implementation by John Costella (at https://johncostella.com/magic/) led to differences when scaling up - the issue turned out to be that this library was applying the sharp filters after upscaling, which are supposed to be done before:

> That implies that we must _first_ apply the three-tap Sharp 2013 kernel, to the input image, before using the Magic Kernel to upsize the result.

(From [here](https://johncostella.com/magic/#:~:text=that%20implies%20that%20we%20must%20first%20apply%20the%20three-tap%20sharp%202013%20kernel%2C%20to%20the%20input%20image%2C%20before%20using%20the%20magic%20kernel%20to%20upsize%20the%20result.).)

I don't work in Rust often, so if there's a more idiomatic way to implement this, please feel free to close the PR and do so.
